### PR TITLE
Fixed issue when missing attributes are queried on not found node

### DIFF
--- a/lib/rspec/sitemap/matchers/include_url.rb
+++ b/lib/rspec/sitemap/matchers/include_url.rb
@@ -45,7 +45,7 @@ module RSpec::Sitemap::Matchers
       attributes = {}
       matched_node.children.each do |node|
         attributes[node.name.to_sym] = node.text
-      end
+      end unless matched_node.nil?
       attributes
     end
 

--- a/spec/rspec/sitemap/matchers/include_url_spec.rb
+++ b/spec/rspec/sitemap/matchers/include_url_spec.rb
@@ -43,6 +43,18 @@ module RSpec::Sitemap::Matchers
       end
     end
 
+    describe "#failure_message" do
+
+      let(:sitemap) { fixture('basic').read }
+
+      it "should not raise error when attributes are queried on missing url" do
+        expect {
+          # not included url
+          sitemap.should include_url('http://www.example.org').priority(0.5)
+        }.to_not raise_error NoMethodError
+      end
+    end
+
     describe "#priority" do
       context "when it is set" do
         let(:sitemap) { fixture('with_valid_priority') }


### PR DESCRIPTION
I've used your matcher and it raises an error when it try to match attributes on missing urls.

Spec provided.
