### PR TITLE
Matchers for other sitemap elements

### DIFF
--- a/lib/rspec/sitemap/matchers/include_url.rb
+++ b/lib/rspec/sitemap/matchers/include_url.rb
@@ -1,5 +1,8 @@
 module RSpec::Sitemap::Matchers
   class IncludeUrl
+
+    ALLOWED_ATTRS = %w(priority changefreq lastmod)
+
     def initialize(expected_location)
       @expected_location = expected_location
     end
@@ -37,6 +40,10 @@ module RSpec::Sitemap::Matchers
     def changefreq(expected_changefreq)
       expected_attributes.merge!(:changefreq => expected_changefreq)
       self
+    end
+
+    ALLOWED_ATTRS.each do |attr|
+      alias_method "with_#{attr}".to_sym, attr.to_sym
     end
 
     private

--- a/lib/rspec/sitemap/matchers/include_url.rb
+++ b/lib/rspec/sitemap/matchers/include_url.rb
@@ -29,7 +29,17 @@ module RSpec::Sitemap::Matchers
       self
     end
 
-  private
+    def lastmod(expected_lastmod)
+      expected_attributes.merge!(:lastmod => expected_lastmod)
+      self
+    end
+
+    def changefreq(expected_changefreq)
+      expected_attributes.merge!(:changefreq => expected_changefreq)
+      self
+    end
+
+    private
 
     def expected_attributes
       @expected_attributes ||= {}

--- a/spec/rspec/sitemap/matchers/include_url_spec.rb
+++ b/spec/rspec/sitemap/matchers/include_url_spec.rb
@@ -44,31 +44,30 @@ module RSpec::Sitemap::Matchers
     end
 
     describe "#priority" do
-      context "when it is set" do
-        let(:sitemap) { fixture('with_valid_priority') }
-        it "passes" do
-          sitemap.should include_url('http://www.example.com').priority('0.5')
-        end
 
-        it "fails" do
-          expect {
-            sitemap.should include_url('http://www.example.com').priority('0.8')
-          }.to raise_error { |error|
-            error.message.should match('to include a URL to http://www.example.com with a priority of 0.8 but it was set to 0.5')
-          }
-        end
+      it_should_behave_like "an attribute matcher", "priority", 0.5, 0.8 do
+        let(:passing_sitemap) { fixture('with_valid_priority') }
+        let(:failing_sitemap) { fixture('basic') }
       end
 
-      context "when it is NOT set" do
-        let(:sitemap) { fixture('basic') }
-        it "fails" do
-          expect {
-            sitemap.should include_url('http://www.example.com').priority('0.5')
-          }.to raise_error { |error|
-            error.message.should match('to include a URL to http://www.example.com with a priority of 0.5 but the priority was not set')
-          }
-        end
+    end
+
+    describe "#changefreq" do
+
+      it_should_behave_like "an attribute matcher", "changefreq", "weekly", "daily" do
+        let(:passing_sitemap) { fixture('with_valid_priority') }
+        let(:failing_sitemap) { fixture('basic') }
       end
+
+    end
+
+    describe "#lastmod" do
+
+      it_should_behave_like "an attribute matcher", "lastmod", "2012-11-27T16:40:53+01:00", "not prova" do
+        let(:passing_sitemap) { fixture('with_valid_priority') }
+        let(:failing_sitemap) { fixture('basic') }
+      end
+
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@
 
 require 'rspec/sitemap/matchers'
 require 'support/fixture_helper'
+require 'support/attribute_shared_examples'
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true

--- a/spec/support/attribute_shared_examples.rb
+++ b/spec/support/attribute_shared_examples.rb
@@ -1,0 +1,29 @@
+shared_examples_for "an attribute matcher" do |attribute, expected, not_expected|
+
+  context "when #{attribute} is set" do
+
+    it "passes" do
+      passing_sitemap.should include_url('http://www.example.com').send(attribute, expected)
+    end
+
+    it "fails" do
+      expect {
+        passing_sitemap.should include_url('http://www.example.com').send(attribute, not_expected)
+      }.to raise_error { |error|
+        error.message.should include("to include a URL to http://www.example.com with a #{attribute} of #{not_expected} but it was set to #{expected}")
+      }
+    end
+  end
+
+  context "when #{attribute} is NOT set" do
+
+    it "fails" do
+      expect {
+        failing_sitemap.should include_url('http://www.example.com').send(attribute, expected)
+      }.to raise_error { |error|
+        error.message.should include("to include a URL to http://www.example.com with a #{attribute} of #{expected} but the #{attribute} was not set")
+      }
+    end
+  end
+
+end

--- a/spec/support/attribute_shared_examples.rb
+++ b/spec/support/attribute_shared_examples.rb
@@ -6,6 +6,10 @@ shared_examples_for "an attribute matcher" do |attribute, expected, not_expected
       passing_sitemap.should include_url('http://www.example.com').send(attribute, expected)
     end
 
+    it "passes when invoked with with_ syntax" do
+      passing_sitemap.should include_url('http://www.example.com').send("with_#{attribute}", expected)
+    end
+
     it "fails" do
       expect {
         passing_sitemap.should include_url('http://www.example.com').send(attribute, not_expected)

--- a/spec/support/fixtures/sitemaps/with_valid_priority.xml
+++ b/spec/support/fixtures/sitemaps/with_valid_priority.xml
@@ -3,5 +3,7 @@
   <url>
     <loc>http://www.example.com</loc>
     <priority>0.5</priority>
+    <lastmod>2012-11-27T16:40:53+01:00</lastmod>
+    <changefreq>weekly</changefreq>
   </url>
 </urlset>


### PR DESCRIPTION
Added other attributes matchers and also with syntax to do calls as in

```
it { should include_url('xxx').with_priority(0.5) }
```
