### PR TITLE
support failure_message_when_negated

### DIFF
--- a/lib/rspec/sitemap/matchers/include_url.rb
+++ b/lib/rspec/sitemap/matchers/include_url.rb
@@ -27,6 +27,12 @@ module RSpec::Sitemap::Matchers
       end.join(' ')
     end
 
+    def failure_message_when_negated
+      "expected #{@actual} not to include a URL to #{@expected_location} but it did"
+    end
+
+
+    
     def priority(expected_priority)
       expected_attributes.merge!(:priority => expected_priority)
       self


### PR DESCRIPTION
Hey I can see this library hasn't been touched in a while. So not sure if you're still maintaining it.
This PR adds rudimentary support without tests for a presumably much newer feature of rspec core being the `#failure_message_when_negated method` on an `RSpec::Matcher`

This works around the following issue

```
     Failure/Error:
       expect(subject).not_to include_url(
         'https://example.com/hidden-from-search-engines'
       )
     
     NoMethodError:
       undefined method `failure_message_when_negated' for #<RSpec::Sitemap::Matchers::IncludeUrl:0x000055ba33258b98>
       Did you mean?  failure_message
     # /home/mark/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/handler.rb:36:in `handle_failure'
     # /home/mark/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/handler.rb:73:in `block in handle_matcher'
     # /home/mark/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/mark/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/handler.rb:71:in `handle_matcher'
     # /home/mark/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.7.0/lib/rspec/expectations/expectation_target.rb:78:in `not_to'
     # ./spec/services/sitemap_service_spec.rb:468:in `block (7 levels) in <main>'
```


Anyway, I thought I'd open this speculative pull request as a conversation starter, to see if you wanted to do something with it.
I suppose technically it shouldn't break with older RSpec versions, so you may not need to add any kind of backwards compatibility check or something like `appraisals`.

Let me know if you'd like me to do anything further with this.